### PR TITLE
change: tweed remove smallest size, change images

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,10 +342,6 @@
 							<table class="alt">
 								<tbody>
 									<tr>
-										<td>100x140</td>
-										<td>75€</td>
-									</tr>
-									<tr>
 										<td>135x195</td>
 										<td>149€</td>
 									</tr>
@@ -361,8 +357,8 @@
 							</table>
 						</div>
 						<div class="carpets">
-							<img src="/cdn-cgi/image/width=480,height=480,fit=pad,background=transparent,format=auto,quality=80/https://mattokuvasto.kyse.fi/935/935_0006_4141-45_NA.jpg" alt="" class="fit" />
-							<img src="/cdn-cgi/image/width=480,height=480,fit=pad,background=transparent,format=auto,quality=81/https://mattokuvasto.kyse.fi/935/935_0006_1111-15_NA.jpg" alt="" class="fit" />
+							<img src="/cdn-cgi/image/width=480,height=480,fit=pad,background=transparent,format=auto,quality=80/https://mattokuvasto.kyse.fi/2026/tweed-6161-65.jpg" alt="" class="fit" />
+							<img src="/cdn-cgi/image/width=480,height=480,fit=pad,background=transparent,format=auto,quality=81/https://mattokuvasto.kyse.fi/2026/tweed-4141-45.jpg" alt="" class="fit" />
 						</div>
 						<ul class="actions stacked">
 							<li><a href="#villamatto" style="padding-left:5px; padding-right:5px;" class="button fit wide smooth-scroll">Seuraava: käsinsolmitut matot</a></li>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed the 100x140 size option (75€) from the Tweed product line.
  * Updated product images in the Tweed collection with new visuals for improved presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->